### PR TITLE
Set neon dependency to github instead of local machine outside of project folder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Dave Herman <dherman@mozilla.com>"]
 license = "MIT"
 
 [dependencies]
-neon = { version = "0.1", path = "../neon" }
+neon = { git = "https://github.com/dherman/neon" }
 rayon = { git = "https://github.com/nikomatsakis/rayon" }


### PR DESCRIPTION
Set neon dependency to github instead of local machine outside of project folder.
Currently is faling to build, since Neon is not found. Tested with Github url and it's working.
