### PR TITLE
Feature/quick npm start

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Dave Herman <dherman@mozilla.com>"]
 license = "MIT"
 
 [dependencies]
-neon = { version = "0.1", path = "../neon" }
+neon = { git = "https://github.com/dherman/neon" }
 rayon = { git = "https://github.com/nikomatsakis/rayon" }

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ From the project root directory, run:
 
 ```
 % npm install
-% node -e 'require("./")'
+% npm start
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "main": "lib/index.js",
   "scripts": {
+    "start": "node lib/index.js",
     "postinstall": "neon build"
   },
   "author": "Dave Herman <dherman@mozilla.com>",


### PR DESCRIPTION
Replace `% node -e 'require("./")'` with `npm start` bit of a preference but also the defacto node way.
