### PR TITLE
Fixing compilation error with string value

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -69,7 +69,7 @@ fn search(call: Call) -> JsResult<JsInteger> {
     let scope = call.scope;
     let buffer: Handle<JsBuffer> = try!(try!(call.arguments.require(scope, 0)).check::<JsBuffer>());
     let string: Handle<JsString> = try!(try!(call.arguments.require(scope, 1)).check::<JsString>());
-    let search = &string.data()[..];
+    let search = &string.value()[..];
     let total = vm::lock(buffer, |data| {
         let corpus = data.as_str().unwrap();
         wc_parallel(&lines(corpus), search)


### PR DESCRIPTION
I just tried running this demo locally on Node Version 5.x (I know that neon officially only supports 4.x), and it did not compile. However, after making the change here, it compiled and executed successfully. 
