### PR TITLE
Switch from tracking master to 0.6.0 for Rayon.

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 neon = "0.1"
-rayon = { git = "https://github.com/nikomatsakis/rayon" }
+rayon = "0.6.0" 


### PR DESCRIPTION
Fixes #12.